### PR TITLE
Disable openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base:v0.2.0
 
 RUN yum upgrade -y -q; yum clean all
-RUN yum install -y -q java-headless tar wget openssl apr; yum clean all
+RUN yum install -y -q java-headless tar wget openssl; yum clean all
 RUN adduser -d /data -m elasticsearch
 
 EXPOSE 9200 9300
@@ -9,7 +9,7 @@ EXPOSE 9200 9300
 ENV ES_VERSION 2.2.1
 RUN wget -q https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz -O - | tar -xzf -; mv elasticsearch-${ES_VERSION} /elasticsearch && mkdir -p /elasticsearch/config/scripts /elasticsearch/plugins
 RUN /elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/${ES_VERSION}
-RUN /elasticsearch/bin/plugin install com.floragunn/search-guard-ssl/2.2.1.7 && (cd /elasticsearch/plugins/search-guard-ssl/ && wget -q http://repo1.maven.org/maven2/io/netty/netty-tcnative/1.1.33.Fork13/netty-tcnative-1.1.33.Fork13-linux-x86_64-fedora.jar)
+RUN /elasticsearch/bin/plugin install com.floragunn/search-guard-ssl/2.2.1.7
 
 VOLUME /data
 WORKDIR /elasticsearch


### PR DESCRIPTION
Disabling openssl for now. I discovered that using openssl with java makes
elasticsearch to leak memory.

See https://github.com/floragunncom/search-guard-ssl/issues/15
