### PR TITLE
Adds x-pack for monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV ES_VERSION 5.1.1
 RUN wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz -O - | tar -xzf -; mv elasticsearch-${ES_VERSION} /elasticsearch && mkdir -p /elasticsearch/config/scripts /elasticsearch/plugins
 RUN /elasticsearch/bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.1.1
 RUN /elasticsearch/bin/elasticsearch-plugin install com.floragunn:search-guard-ssl:5.1.1-19 && (cd /elasticsearch/plugins/search-guard-ssl/ && wget -q http://repo1.maven.org/maven2/io/netty/netty-tcnative/1.1.33.Fork24/netty-tcnative-1.1.33.Fork24-linux-x86_64-fedora.jar)
+RUN /elasticsearch/bin/elasticsearch-plugin install x-pack && \
+    chmod 0755 /elasticsearch/config/x-pack && \
+    chmod 0644 /elasticsearch/config/x-pack/*
 
 VOLUME /data
 WORKDIR /elasticsearch

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -37,3 +37,6 @@ searchguard.ssl.transport.truststore_alias: ca
 # searchguard.ssl.http.keystore_alias: cert
 # searchguard.ssl.http.truststore_filepath: certs/truststore.jks
 # searchguard.ssl.http.truststore_alias: ca
+
+# TODO: Evaluate whether it's worth paying for X-Pack advanced features. Basic monitoring is free.
+xpack.security.enabled: false


### PR DESCRIPTION
Enables Elastic X-Pack. There is 30-day trial license installed by default. After it expires it'll downgrade most of X-Pack features unless we decide to get the licence. Free license includes basic monitoring though and this is what we're after at the moment. I've disabled trial security plugin as it requires quite a lot of configuration and should be evaluated before we use it. 