### PR TITLE
Upgrades to 5.6.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,16 @@ RUN groupadd -r -g 1000 elasticsearch && adduser -d /data -m -u 1000 -g 1000 ela
 
 EXPOSE 9200 9300
 
-ENV ES_VERSION 5.5.1
+ENV ES_VERSION 5.6.16
 RUN wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz -O - | tar -xzf -; mv elasticsearch-${ES_VERSION} /elasticsearch && mkdir -p /elasticsearch/config/scripts /elasticsearch/plugins
-RUN /elasticsearch/bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.5.1
-RUN /elasticsearch/bin/elasticsearch-plugin install com.floragunn:search-guard-ssl:5.5.1-23 && (cd /elasticsearch/plugins/search-guard-ssl/ && wget -q http://repo1.maven.org/maven2/io/netty/netty-tcnative/1.1.33.Fork24/netty-tcnative-1.1.33.Fork24-linux-x86_64-fedora.jar)
+RUN /elasticsearch/bin/elasticsearch-plugin install com.floragunn:search-guard-ssl:5.6.16-23 && (cd /elasticsearch/plugins/search-guard-ssl/ && wget -q http://repo1.maven.org/maven2/io/netty/netty-tcnative/1.1.33.Fork24/netty-tcnative-1.1.33.Fork24-linux-x86_64-fedora.jar)
 RUN /elasticsearch/bin/elasticsearch-plugin install x-pack && \
     chmod 0755 /elasticsearch/config/x-pack && \
     chmod 0644 /elasticsearch/config/x-pack/*
 RUN /elasticsearch/bin/elasticsearch-plugin install repository-s3
+
+COPY config/ /elasticsearch/config/
+
 RUN chown -R elasticsearch:elasticsearch /data /elasticsearch
 
 USER 1000
@@ -21,7 +23,6 @@ USER 1000
 VOLUME /data
 WORKDIR /elasticsearch
 
-COPY config/ /elasticsearch/config/
 COPY run.sh /run.sh
 
 CMD /run.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/UKHomeOffice/docker-elasticsearch.svg?branch=master)](https://travis-ci.org/UKHomeOffice/docker-elasticsearch)
 [![Docker Repository on Quay](https://quay.io/repository/ukhomeofficedigital/elasticsearch/status "Docker Repository on Quay")](https://quay.io/repository/ukhomeofficedigital/elasticsearch)
 
-ElasticSearch 5.5.1 with kubernetes discovery plugin for simple deployment and
+ElasticSearch 5.6.16 with kubernetes discovery plugin for simple deployment and
 discovery.
 
 ### Configuration
@@ -13,7 +13,6 @@ values in [kube/](kube/) example files.
 
 * `CLUSTER_NAME`: ElasticSearch cluster name. Default: `elasticsearch`.
 * `NODE_NAME`: Node name. Default: `${HOSTNAME}` (kubernetes assigned pod name by default).
-* `NODE_LOCAL`: If set to true it will prevent the elasticsearch node from discovering other nodes on the network. Default: `false`.
 * `PATH_DATA`: Path where ES stores its data. Default: `/data`.
 * `ELASTIC_SEARCH_HEAP_SIZE`: JVM heap size. Default: `450m`. If you adjust this parameter,
   make sure to increase container limits as well.
@@ -24,6 +23,7 @@ values in [kube/](kube/) example files.
 * `INDEX_REFRESH_INTERVAL`: How often to refresh indexes. Default: `1s`.
 * `GATEWAY_EXPECTED_MASTER_NODES` - See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html
 * `GATEWAY_EXPECTED_DATA_NODES` - See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html
+* `MEM_LOCK` - Whether to enable bootstrap.memory_lock. Default: `true`.
 * `NODE_MASTER`: Whether this node can be a master node. Default: `true`.
 * `NODE_DATA`: Whether this node can be a data node. Default: `true`.
 * `NODE_INGEST`: Whether this node can be a data ingesting node. Default: `true`.
@@ -31,17 +31,17 @@ values in [kube/](kube/) example files.
 * `HTTP_BIND_HOST`: http bind address.. Default: `0.0.0.0`.
 * `KUBERNETES_SERVICE`: kubernetes service name for master nodes. Default `elasticsearch-master`.
 * `ENABLE_TRANSPORT_SSL`: whether to enable search-guard transport SSL. Default: `false`.
-* `DISCOVERY_TYPE`: The type of discovery for your cluster to use. Default `kubernetes`.
 * `DISCOVERY_ZEN_FD_PING_INTERVAL` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection
 * `DISCOVERY_ZEN_FD_PING_TIMEOUT` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection
 * `DISCOVERY_ZEN_FD_PING_RETRIES` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection
 * `DISCOVERY_ZEN_PUBLISH_TIMEOUT` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#_cluster_state_updates
+* `DISCOVERY_ZEN_UNICAST_HOST` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection. Default `elasticsearch`
 * `DISCOVERY_ZEN_MINIMUM_MASTER_NODES` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#master-election. Default: `1`
 * `THREAD_POOL_BULK_QUEUE_SIZE` - see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-threadpool.html
 * `INDEX_BUFFER_SIZE` - see https://www.elastic.co/guide/en/elasticsearch/reference/5.1/indexing-buffer.html
-* `CLOUD_AWS_S3_ACCESS_KEY` - Cloud AWS S3 access key for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/5.5/repository-s3.html
-* `CLOUD_AWS_S3_SECRET_KEY` - Cloud AWS S3 secret key for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/5.5/repository-s3.html
-* `CLOUD_AWS_S3_REGION` - Cloud AWS S3 region for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/5.5/repository-s3.html
+* `CLOUD_AWS_S3_ACCESS_KEY` - Cloud AWS S3 access key for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/6.8/repository-s3-client.html
+* `CLOUD_AWS_S3_SECRET_KEY` - Cloud AWS S3 secret key for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/6.8/repository-s3-client.html
+* `CLOUD_AWS_S3_ENDPOINT` - Cloud AWS S3 endpoint for repository-s3 plugin. See https://www.elastic.co/guide/en/elasticsearch/plugins/6.8/repository-s3-client.html
 * `XPACK_SECURITY_ENABLE` - Whether X-Pack security plugin is enabled. Default: `false`
 * `XPACK_SECURITY_AUDIT_ENABLE` - Whether to enable auditing to keep track of attempted and successful interactions with Elasticsearch cluster. Default: `false`.
 * `XPACK_SECURITY_AUDIT_INDEX_EVENTS_EXCLUDE` - Excludes the specified auditing events from indexing. By default, no events are excluded. Accepts a string value with comma separated events. See https://www.elastic.co/guide/en/elasticsearch/reference/5.5/auditing-settings.html#index-audit-settings
@@ -66,11 +66,6 @@ values in [kube/](kube/) example files.
 
 
 ### Plugins
-#### Kubernetes Discovery
-For more kubernetes discovery plugin related options, see
-https://github.com/fabric8io/kubernetes-client. Our examples use just a
-standard kubernetes auth token to authenticate against the kubernetes API for
-discovery.
 
 #### Search Guard SSL
 If you want to use transport TLS, please take a look at their documentation

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -43,7 +43,7 @@ if docker ps -a | grep es_thing ; then
 fi
 
 docker build -t es .
-${SUDO_CMD}  docker run --ulimit=nofile=65536:65536 --ulimit=memlock=-1:-1 --name es_thing -d -p 9200:9200 -p 9300:9300 -e NODE_LOCAL=true es
+${SUDO_CMD}  docker run --ulimit=nofile=65536:65536 --ulimit=memlock=-1:-1 --name es_thing -d -p 9200:9200 -p 9300:9300 es
 get http://${DOCKER_HOST_NAME}:9200/
 docker logs es_thing
 get http://${DOCKER_HOST_NAME}:9200/_cluster/health?pretty

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -4,13 +4,12 @@ cluster.name: ${CLUSTER_NAME}
 node.name: ${NODE_NAME}
 node.master: ${NODE_MASTER}
 node.data: ${NODE_DATA}
-node.local: ${NODE_LOCAL}
 node.ingest: ${NODE_INGEST}
 
 path.data: ${PATH_DATA}
 path.logs: ${PATH_DATA}/logs
 
-bootstrap.memory_lock: true
+bootstrap.memory_lock: ${MEM_LOCK}
 
 gateway.expected_master_nodes: ${GATEWAY_EXPECTED_MASTER_NODES}
 gateway.expected_data_nodes: ${GATEWAY_EXPECTED_DATA_NODES}
@@ -21,13 +20,13 @@ http.enabled: ${HTTP_ENABLE}
 http.compression: true
 http.bind_host: ${HTTP_BIND_HOST}
 
-cloud.kubernetes.service: ${KUBERNETES_SERVICE}
-cloud.kubernetes.namespace: ${KUBERNETES_NAMESPACE}
-discovery.zen.hosts_provider: ${DISCOVERY_TYPE}
+s3.client.default.endpoint: ${CLOUD_AWS_S3_ENDPOINT}
+
 discovery.zen.fd.ping_interval: ${DISCOVERY_ZEN_FD_PING_INTERVAL}
 discovery.zen.fd.ping_timeout: ${DISCOVERY_ZEN_FD_PING_TIMEOUT}
 discovery.zen.fd.ping_retries: ${DISCOVERY_ZEN_FD_PING_RETRIES}
 discovery.zen.publish_timeout: ${DISCOVERY_ZEN_PUBLISH_TIMEOUT}
+discovery.zen.ping.unicast.hosts: ${DISCOVERY_ZEN_UNICAST_HOST}
 discovery.zen.minimum_master_nodes: ${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}
 
 searchguard.ssl.transport.enabled: ${ENABLE_TRANSPORT_SSL}
@@ -40,15 +39,6 @@ searchguard.ssl.transport.truststore_alias: ca
 
 thread_pool.bulk.queue_size: ${THREAD_POOL_BULK_QUEUE_SIZE}
 indices.memory.index_buffer_size: ${INDEX_BUFFER_SIZE}
-
-cloud.aws.s3.access_key: ${CLOUD_AWS_S3_ACCESS_KEY}
-cloud.aws.s3.secret_key: ${CLOUD_AWS_S3_SECRET_KEY}
-cloud.aws.s3.region: ${CLOUD_AWS_S3_REGION}
-
-# searchguard.ssl.http.keystore_filepath: certs/keystore.jks
-# searchguard.ssl.http.keystore_alias: cert
-# searchguard.ssl.http.truststore_filepath: certs/truststore.jks
-# searchguard.ssl.http.truststore_alias: ca
 
 xpack.security.enabled: ${XPACK_SECURITY_ENABLE}
 xpack.security.transport.ssl.enabled: ${XPACK_SECURITY_TRANSPORT_SSL_ENABLE}
@@ -71,5 +61,3 @@ xpack.notification.email.account.ses_account.smtp.starttls.enable: ${XPACK_EMAIL
 xpack.notification.email.account.ses_account.smtp.starttls.required: ${XPACK_EMAIL_SMTP_STARTTLS_REQUIRED}
 xpack.notification.email.account.ses_account.smtp.host: ${XPACK_EMAIL_SMTP_HOST}
 xpack.notification.email.account.ses_account.smtp.port: ${XPACK_EMAIL_SMTP_PORT}
-xpack.notification.email.account.ses_account.smtp.user: ${XPACK_EMAIL_SMTP_USER}
-xpack.notification.email.account.ses_account.smtp.password: ${XPACK_EMAIL_SMTP_PASS}

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker%m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console

--- a/kube/es-master-svc.yaml
+++ b/kube/es-master-svc.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     service: elasticsearch
     role: master
+  # Headless
+  clusterIP: None
   ports:
     - name: http
       port: 9300

--- a/kube/es-svc.yaml
+++ b/kube/es-svc.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     service: elasticsearch
     role: client
+  # Headless
+  clusterIP: None
   ports:
     - name: http
       port: 9200

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
+add_to_keystore() {
+    if [ "x${1}x" == "xx" ] || [ "x${2}x" == "xx" ]; then
+        echo "Empty values sent to add_to_keystore $1"
+        return
+    else
+        echo $2 | /elasticsearch/bin/elasticsearch-keystore add --stdin $1
+        /elasticsearch/bin/elasticsearch-keystore list $1 > /dev/null 2>&1
+        rc=$?
+        [ $rc -ne 0 ] && "There was an error adding $1 to keystore"
+    fi
+}
+
 export CLUSTER_NAME=${CLUSTER_NAME:=elasticsearch}
 export NODE_NAME=${NODE_NAME:=${HOSTNAME}}
-export NODE_LOCAL=${NODE_LOCAL:=false}
 export NODE_INGEST=${NODE_INGEST:=true}
 export PATH_DATA=${PATH_DATA:=/data}
+export MEM_LOCK=${MEM_LOCK:=true}
 export ELASTIC_SEARCH_HEAP_SIZE=${ELASTIC_SEARCH_HEAP_SIZE:=450m}
 export ES_JAVA_OPTS="${ES_JAVA_OPTS} -Xms${ELASTIC_SEARCH_HEAP_SIZE} -Xmx${ELASTIC_SEARCH_HEAP_SIZE} -Dlog4j2.disable.jmx=true"
 export INDEX_AUTO_EXPAND_REPLICAS=${INDEX_AUTO_EXPAND_REPLICAS:=false}
@@ -13,7 +25,6 @@ export INDEX_NUMBER_OF_REPLICAS=${INDEX_NUMBER_OF_REPLICAS:=1}
 export INDEX_REFRESH_INTERVAL=${INDEX_REFRESH_INTERVAL:=1s}
 export GATEWAY_EXPECTED_MASTER_NODES=${GATEWAY_EXPECTED_MASTER_NODES:=0}
 export GATEWAY_EXPECTED_DATA_NODES=${GATEWAY_EXPECTED_DATA_NODES:=0}
-export DISCOVERY_TYPE=${DISCOVERY_TYPE:=kubernetes}
 export NODE_MASTER=${NODE_MASTER:=true}
 export NODE_DATA=${NODE_DATA:=true}
 export HTTP_ENABLE=${HTTP_ENABLE:=true}
@@ -24,12 +35,13 @@ export DISCOVERY_ZEN_FD_PING_INTERVAL=${DISCOVERY_ZEN_FD_PING_INTERVAL:=1s}
 export DISCOVERY_ZEN_FD_PING_TIMEOUT=${DISCOVERY_ZEN_FD_PING_TIMEOUT:=30s}
 export DISCOVERY_ZEN_FD_PING_RETRIES=${DISCOVERY_ZEN_FD_PING_RETRIES:=3}
 export DISCOVERY_ZEN_PUBLISH_TIMEOUT=${DISCOVERY_ZEN_PUBLISH_TIMEOUT:=30s}
+export DISCOVERY_ZEN_UNICAST_HOST=${DISCOVERY_ZEN_UNICAST_HOST:=elasticsearch}
 export DISCOVERY_ZEN_MINIMUM_MASTER_NODES=${DISCOVERY_ZEN_MINIMUM_MASTER_NODES:=1}
 export THREAD_POOL_BULK_QUEUE_SIZE=${THREAD_POOL_BULK_QUEUE_SIZE:=50}
 export INDEX_BUFFER_SIZE=${INDEX_BUFFER_SIZE:=10%}
 export CLOUD_AWS_S3_ACCESS_KEY=${CLOUD_AWS_S3_ACCESS_KEY:=}
 export CLOUD_AWS_S3_SECRET_KEY=${CLOUD_AWS_S3_SECRET_KEY:=}
-export CLOUD_AWS_S3_REGION=${CLOUD_AWS_S3_REGION:=eu-west-2}
+export CLOUD_AWS_S3_ENDPOINT=${CLOUD_AWS_S3_ENDPOINT:=s3.eu-west-2.amazonaws.com}
 export XPACK_SECURITY_ENABLE=${XPACK_SECURITY_ENABLE:=false}
 export XPACK_SECURITY_AUDIT_ENABLE=${XPACK_SECURITY_AUDIT_ENABLE:=false}
 export XPACK_SECURITY_AUDIT_INDEX_EVENTS_EXCLUDE=${XPACK_SECURITY_AUDIT_INDEX_EVENTS_EXCLUDE:=}
@@ -53,5 +65,13 @@ export XPACK_EMAIL_SMTP_USER=${XPACK_EMAIL_SMTP_USER:=false}
 export XPACK_EMAIL_SMTP_PASS=${XPACK_EMAIL_SMTP_PASS:=false}
 
 export ENABLE_TRANSPORT_SSL=${ENABLE_TRANSPORT_SSL:=false}
+
+# Create keystore
+/elasticsearch/bin/elasticsearch-keystore create
+
+add_to_keystore s3.client.default.access_key ${CLOUD_AWS_S3_ACCESS_KEY}
+add_to_keystore s3.client.default.secret_key ${CLOUD_AWS_S3_SECRET_KEY}
+add_to_keystore xpack.notification.email.account.ses_account.smtp.user ${XPACK_EMAIL_SMTP_USER}
+add_to_keystore xpack.notification.email.account.ses_account.smtp.secure_password ${XPACK_EMAIL_SMTP_PASS}
 
 /elasticsearch/bin/elasticsearch


### PR DESCRIPTION
Upgrades binaries to 5.6.16
Removes searchguard ssl plugin
Removes elasticsearch-cloud-kubernetes plugin
Switches DISCOVERY_TYPE to file and adds unicast_hosts.txt instead.
Removes deprecated NODE_LOCAL setting
Adds an env var to control `bootstrap.memory_lock`: MEM_LOCK
Updates deprecated s3 cloud settings to `s3.client.default` equivalents.