### PR TITLE
5.6.16-2

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -61,3 +61,5 @@ xpack.notification.email.account.ses_account.smtp.starttls.enable: ${XPACK_EMAIL
 xpack.notification.email.account.ses_account.smtp.starttls.required: ${XPACK_EMAIL_SMTP_STARTTLS_REQUIRED}
 xpack.notification.email.account.ses_account.smtp.host: ${XPACK_EMAIL_SMTP_HOST}
 xpack.notification.email.account.ses_account.smtp.port: ${XPACK_EMAIL_SMTP_PORT}
+xpack.notification.email.account.ses_account.smtp.user: ${XPACK_EMAIL_SMTP_USER}
+xpack.notification.email.account.ses_account.smtp.password: ${XPACK_EMAIL_SMTP_PASS}

--- a/run.sh
+++ b/run.sh
@@ -71,7 +71,5 @@ export ENABLE_TRANSPORT_SSL=${ENABLE_TRANSPORT_SSL:=false}
 
 add_to_keystore s3.client.default.access_key ${CLOUD_AWS_S3_ACCESS_KEY}
 add_to_keystore s3.client.default.secret_key ${CLOUD_AWS_S3_SECRET_KEY}
-add_to_keystore xpack.notification.email.account.ses_account.smtp.user ${XPACK_EMAIL_SMTP_USER}
-add_to_keystore xpack.notification.email.account.ses_account.smtp.secure_password ${XPACK_EMAIL_SMTP_PASS}
 
 /elasticsearch/bin/elasticsearch


### PR DESCRIPTION
xpack.email doesn't support keystore in this version

Reverts to using plain-text elasticsearch.yaml config points.